### PR TITLE
fix(operation) RESTful.remove -> RESTful.delete

### DIFF
--- a/client/modules/operation/index.js
+++ b/client/modules/operation/index.js
@@ -105,7 +105,7 @@ function OperationProto(operation, data) {
             });
             
             remover.on('disconnect', () => {
-                deleteFn = RESTful.remove;
+                deleteFn = RESTful.delete;
             });
         });
     }


### PR DESCRIPTION
In OperationProto class, deleteFn is incorrectly set to RESTful.remove, which is undefined, when socket is disconnected.

<!--
Thank you for making pull request. Please fill in the template below. If unsure
about something, just do as best as you're able.
-->

- [✓] commit message named according to [Contributing Guide](https://github.com/coderaiser/cloudcmd/blob/master/CONTRIBUTING.md "Contributting Guide")
- [✓] `npm run codestyle` is OK
- [✓] `npm test` is OK

